### PR TITLE
Add CORS fallback for aviationweather.gov fetches (gh-pages)

### DIFF
--- a/src/__tests__/aviationWeatherApi.spec.ts
+++ b/src/__tests__/aviationWeatherApi.spec.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchJsonWithFallback } from '@/composables/aviationWeatherApi'
+
+describe('fetchJsonWithFallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to corsproxy.io when direct call fails', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ icaoId: 'KJFK' }],
+      } as Response)
+
+    const result = await fetchJsonWithFallback<Array<{ icaoId: string }>>([
+      'https://aviationweather.gov/api/data/metar?ids=KJFK&format=json',
+      'https://corsproxy.io/?https%3A%2F%2Faviationweather.gov%2Fapi%2Fdata%2Fmetar%3Fids%3DKJFK%26format%3Djson',
+    ])
+
+    expect(result).toEqual([{ icaoId: 'KJFK' }])
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://aviationweather.gov/api/data/metar?ids=KJFK&format=json',
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://corsproxy.io/?https%3A%2F%2Faviationweather.gov%2Fapi%2Fdata%2Fmetar%3Fids%3DKJFK%26format%3Djson',
+    )
+  })
+})

--- a/src/composables/aviationWeatherApi.ts
+++ b/src/composables/aviationWeatherApi.ts
@@ -1,0 +1,39 @@
+function buildAviationWeatherEndpoint(path: string): string {
+  return `https://aviationweather.gov/api/data${path}`
+}
+
+function withCorsProxy(url: string): string {
+  return `https://corsproxy.io/?${encodeURIComponent(url)}`
+}
+
+export async function fetchJsonWithFallback<T>(urls: string[]): Promise<T> {
+
+  let lastError: unknown = null
+
+  for (const url of urls) {
+    try {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      }
+
+      return (await response.json()) as T
+    } catch (err) {
+      lastError = err
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Unable to fetch Aviation Weather data')
+}
+
+export async function fetchAviationWeatherJson<T>(path: string): Promise<T> {
+  const directUrl = buildAviationWeatherEndpoint(path)
+
+  if (import.meta.env.DEV) {
+    return fetchJsonWithFallback<T>([`/api/avwx${path}`])
+  }
+
+  // gh-pages deployments can hit CORS restrictions when calling the API directly.
+  // Try direct first, then transparently fall back to a CORS proxy.
+  return fetchJsonWithFallback<T>([directUrl, withCorsProxy(directUrl)])
+}

--- a/src/composables/useAirportInfo.ts
+++ b/src/composables/useAirportInfo.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import type { FetchStatus, MagneticCorrection } from '@/types/wind'
+import { fetchAviationWeatherJson } from '@/composables/aviationWeatherApi'
 
 interface AirportInfo {
   icaoId: string
@@ -34,18 +35,10 @@ export function useAirportInfo() {
     console.log('Fetching airport info…')
 
     try {
-      const base = import.meta.env.DEV ? '/api/avwx' : 'https://aviationweather.gov/api/data'
-      const url = `${base}/airport?ids=${encodeURIComponent(icao.toUpperCase())}&format=json`
-      console.log('URL:', url)
+      const path = `/airport?ids=${encodeURIComponent(icao.toUpperCase())}&format=json`
+      console.log('Path:', path)
 
-      const response = await fetch(url)
-      console.log(`HTTP ${response.status} ${response.statusText}`)
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-      }
-
-      const data = await response.json()
+      const data = await fetchAviationWeatherJson<unknown>(path)
 
       if (!Array.isArray(data) || data.length === 0) {
         throw new Error(`No airport data found for ${icao.toUpperCase()}`)

--- a/src/composables/useMetar.ts
+++ b/src/composables/useMetar.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import type { FetchStatus, MetarData, ParsedWind } from '@/types/wind'
+import { fetchAviationWeatherJson } from '@/composables/aviationWeatherApi'
 
 export function useMetar() {
   const status = ref<FetchStatus>('idle')
@@ -16,18 +17,10 @@ export function useMetar() {
     console.log('Fetching METAR…')
 
     try {
-      const base = import.meta.env.DEV ? '/api/avwx' : 'https://aviationweather.gov/api/data'
-      const url = `${base}/metar?ids=${encodeURIComponent(icao.toUpperCase())}&format=json`
-      console.log('URL:', url)
+      const path = `/metar?ids=${encodeURIComponent(icao.toUpperCase())}&format=json`
+      console.log('Path:', path)
 
-      const response = await fetch(url)
-      console.log(`HTTP ${response.status} ${response.statusText}`)
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-      }
-
-      const data = await response.json()
+      const data = await fetchAviationWeatherJson<unknown>(path)
 
       if (!Array.isArray(data) || data.length === 0) {
         throw new Error(`No METAR data found for ${icao.toUpperCase()}`)


### PR DESCRIPTION
### Motivation
- Resolve CORS failures observed on GitHub Pages when the app fetches METAR and airport data from `aviationweather.gov` by providing a production-safe fallback.
- Keep existing local development behavior using the Vite proxy (`/api/avwx`) while adding transparent retry logic for production builds.

### Description
- Add `src/composables/aviationWeatherApi.ts` with `fetchJsonWithFallback` and `fetchAviationWeatherJson` that try the direct `https://aviationweather.gov/api/data` endpoint and fall back to `https://corsproxy.io/` when needed.
- Update `src/composables/useMetar.ts` to use `fetchAviationWeatherJson` for METAR requests and to log `path` instead of calling `fetch` directly.
- Update `src/composables/useAirportInfo.ts` to use `fetchAviationWeatherJson` for airport info requests and to log `path` instead of calling `fetch` directly.
- Add unit test `src/__tests__/aviationWeatherApi.spec.ts` that verifies `fetchJsonWithFallback` retries the proxy URL when the direct call fails.

### Testing
- Ran the unit test with `npm run test:unit -- src/__tests__/aviationWeatherApi.spec.ts`, which passed successfully.
- Built the production bundle with `npm run build`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07e412adc8322a9aa9756f3ba4442)