### PR TITLE
fix: unblock gh-pages build TypeScript check

### DIFF
--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -18,7 +18,8 @@ export function normalizePathForBase(pathname: string, baseUrl: string): string 
 
   let consumedBaseSegments = 0
   while (consumedBaseSegments < segments.length) {
-    if (segments[consumedBaseSegments].toLowerCase() !== baseSegment) break
+    const currentSegment = segments[consumedBaseSegments]
+    if (currentSegment === undefined || currentSegment.toLowerCase() !== baseSegment) break
     consumedBaseSegments += 1
   }
 


### PR DESCRIPTION
## Summary
- guard indexed path segment access in base-path normalizer
- fixes strict TypeScript error in GitHub Pages build

## Validation
- npm run build