### PR TITLE
build: dynamic Vite base path for GitHub Pages and root-hosted deploys

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,8 @@ import vue from "@vitejs/plugin-vue";
 import vueDevTools from "vite-plugin-vue-devtools";
 
 // https://vite.dev/config/
+const isGitHubPagesBuild = process.env.GITHUB_ACTIONS === "true";
+
 export default defineConfig({
   plugins: [vue(), vueDevTools()],
   resolve: {
@@ -21,5 +23,5 @@ export default defineConfig({
       },
     },
   },
-  base: "/A220Tools/",
+  base: isGitHubPagesBuild ? "/A220Tools/" : "/",
 });


### PR DESCRIPTION
### Motivation
- The app was always built with a fixed `base` of `/A220Tools/`, which breaks root-hosted previews (e.g., Netlify) by pointing asset URLs to a non-existent subpath.

### Description
- Updated `vite.config.ts` to set `base` dynamically using `process.env.GITHUB_ACTIONS === "true"` so GitHub Pages builds keep `/A220Tools/` while non-GitHub builds default to `/`.
- This change keeps GitHub Pages behavior for master releases while allowing dev and preview deployments on root hosts to load assets correctly.
- Only `vite.config.ts` was modified.

### Testing
- Ran `npm run test:unit` and all unit tests passed (`45` tests passed).
- Ran `npm run lint` and linters completed with no errors.
- Ran `npm run build` successfully to produce a production build.
- Ran `GITHUB_ACTIONS=true npm run build-only` to validate the GitHub Pages-style build and it completed successfully; a direct `curl` to the Netlify site was blocked by a network proxy (HTTP 403) so remote verification could not be performed from this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a90484648322a178acc1b3e38772)