### PR TITLE
fix: reject stale METAR data and show observation freshness

### DIFF
--- a/src/__tests__/AssumptionsDisplay.spec.ts
+++ b/src/__tests__/AssumptionsDisplay.spec.ts
@@ -35,11 +35,15 @@ describe('AssumptionsDisplay', () => {
     })
 
     const panel = wrapper.get('[data-testid="assumptions-panel"]')
-    expect(panel.isVisible()).toBe(false)
+    const toggle = wrapper.get('[data-testid="assumptions-toggle"]')
 
-    await wrapper.get('[data-testid="assumptions-toggle"]').trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    expect(panel.attributes('style')).toContain('display: none')
 
-    expect(panel.isVisible()).toBe(true)
+    await toggle.trigger('click')
+
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(panel.attributes('style') ?? '').not.toContain('display: none')
   })
 
   it('does not render ATIS advisory copy for METAR results', () => {

--- a/src/__tests__/WindCheckerApp.test.ts
+++ b/src/__tests__/WindCheckerApp.test.ts
@@ -136,12 +136,12 @@ describe('WindCheckerApp', () => {
     await fetchButton.trigger('click')
     await flushAsyncUpdates()
 
-    expect(wrapper.text()).toContain('Updated just now')
+    expect(wrapper.text()).toContain('Observed just now')
 
     await vi.advanceTimersByTimeAsync(60_000)
     await nextTick()
 
-    expect(wrapper.text()).toContain('Updated 1 min ago')
+    expect(wrapper.text()).toContain('Observed 1 min ago')
   })
 
   it('auto-refreshes METAR every 5 minutes while online after success', async () => {

--- a/src/__tests__/useMetar.spec.ts
+++ b/src/__tests__/useMetar.spec.ts
@@ -15,8 +15,8 @@ describe('useMetar', () => {
     vi.useRealTimers()
   })
 
-  it('stores lastFetchedAt on successful METAR fetch', async () => {
-    vi.setSystemTime(new Date('2026-01-15T10:00:00'))
+  it('stores fetch and observation timestamps on successful METAR fetch', async () => {
+    vi.setSystemTime(new Date('2026-01-15T10:00:00Z'))
     vi.mocked(fetchAviationWeatherJson).mockResolvedValue([
       {
         icaoId: 'KSEA',
@@ -34,11 +34,35 @@ describe('useMetar', () => {
     await metar.fetchMetar('KSEA')
 
     expect(metar.status.value).toBe('success')
-    expect(metar.lastFetchedAt.value).toBe(new Date('2026-01-15T10:00:00').getTime())
+    expect(metar.lastFetchedAt.value).toBe(new Date('2026-01-15T10:00:00Z').getTime())
+    expect(metar.metar.value?.issuedAt).toBe(new Date('2026-01-15T10:00:00Z').getTime())
+  })
+
+  it('rejects excessively stale METAR responses', async () => {
+    vi.setSystemTime(new Date('2026-01-15T14:30:00Z'))
+    vi.mocked(fetchAviationWeatherJson).mockResolvedValue([
+      {
+        icaoId: 'KSEA',
+        rawOb: 'KSEA 151000Z 24015KT 10SM CLR 03/M02 A3010',
+        wdir: 240,
+        wspd: 15,
+        wgst: null,
+        lat: 47.45,
+        lon: -122.31,
+        name: 'Seattle Tacoma Intl',
+      },
+    ])
+
+    const metar = useMetar()
+    await metar.fetchMetar('KSEA')
+
+    expect(metar.status.value).toBe('error')
+    expect(metar.error.value).toContain('METAR is stale')
+    expect(metar.metar.value).toBeNull()
   })
 
   it('retains lastFetchedAt after a later fetch error', async () => {
-    const firstSuccessTime = new Date('2026-01-15T10:00:00')
+    const firstSuccessTime = new Date('2026-01-15T10:00:00Z')
     vi.setSystemTime(firstSuccessTime)
     vi.mocked(fetchAviationWeatherJson).mockResolvedValueOnce([
       {
@@ -56,7 +80,7 @@ describe('useMetar', () => {
     const metar = useMetar()
     await metar.fetchMetar('KSEA')
 
-    vi.setSystemTime(new Date('2026-01-15T10:05:00'))
+    vi.setSystemTime(new Date('2026-01-15T10:05:00Z'))
     vi.mocked(fetchAviationWeatherJson).mockRejectedValueOnce(new Error('Network down'))
     await metar.fetchMetar('KSEA')
 

--- a/src/components/WindCheckerApp.vue
+++ b/src/components/WindCheckerApp.vue
@@ -148,11 +148,15 @@ const manualModeToggle = computed({
 });
 
 const metarFreshnessText = computed(() => {
-  if (!isOnline.value || lastFetchedAt.value === null) return null;
-  const elapsedMs = Math.max(0, freshnessNowMs.value - lastFetchedAt.value);
+  if (!isOnline.value || metar.value === null) return null;
+  const referenceTime = metar.value.issuedAt ?? lastFetchedAt.value;
+  if (referenceTime === null) return null;
+
+  const elapsedMs = Math.max(0, freshnessNowMs.value - referenceTime);
   const elapsedMin = Math.floor(elapsedMs / 60_000);
-  const relative = elapsedMin === 0 ? 'Updated just now' : `Updated ${elapsedMin} min ago`;
-  const absolute = new Date(lastFetchedAt.value).toLocaleTimeString([], {
+  const prefix = metar.value.issuedAt !== null ? 'Observed' : 'Updated';
+  const relative = elapsedMin === 0 ? `${prefix} just now` : `${prefix} ${elapsedMin} min ago`;
+  const absolute = new Date(referenceTime).toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
   });

--- a/src/composables/useMetar.ts
+++ b/src/composables/useMetar.ts
@@ -1,6 +1,47 @@
 import { ref } from 'vue'
 import type { FetchStatus, MetarData, ParsedWind } from '@/types/wind'
 import { fetchAviationWeatherJson } from '@/composables/aviationWeatherApi'
+import { METAR_MAX_AGE_MINUTES } from '@/constants/metar'
+
+function parseMetarIssuedAtFromRaw(rawOb: string, nowMs: number): number | null {
+  const match = /\b(\d{2})(\d{2})(\d{2})Z\b/.exec(rawOb)
+  if (!match) return null
+
+  const day = Number(match[1])
+  const hour = Number(match[2])
+  const minute = Number(match[3])
+
+  if (day < 1 || day > 31 || hour > 23 || minute > 59) return null
+
+  const now = new Date(nowMs)
+  let year = now.getUTCFullYear()
+  let month = now.getUTCMonth()
+  let candidate = Date.UTC(year, month, day, hour, minute)
+
+  if (candidate > nowMs) {
+    month -= 1
+    if (month < 0) {
+      month = 11
+      year -= 1
+    }
+    candidate = Date.UTC(year, month, day, hour, minute)
+  }
+
+  return candidate
+}
+
+function resolveMetarIssuedAt(raw: Record<string, unknown>, nowMs: number): number | null {
+  const obsTime = raw.obsTime
+  if (typeof obsTime === 'string') {
+    const parsed = Date.parse(obsTime)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+
+  const rawOb = typeof raw.rawOb === 'string' ? raw.rawOb : ''
+  return parseMetarIssuedAtFromRaw(rawOb, nowMs)
+}
 
 export function useMetar() {
   const status = ref<FetchStatus>('idle')
@@ -46,6 +87,17 @@ export function useMetar() {
 
       const wdir = raw.wdir === 'VRB' ? 'VRB' : typeof raw.wdir === 'number' ? raw.wdir : null
 
+      const nowMs = Date.now()
+      const issuedAt = resolveMetarIssuedAt(raw, nowMs)
+      if (issuedAt !== null) {
+        const ageMinutes = Math.floor((nowMs - issuedAt) / 60_000)
+        if (ageMinutes > METAR_MAX_AGE_MINUTES) {
+          throw new Error(
+            `METAR is stale (${ageMinutes} min old, max ${METAR_MAX_AGE_MINUTES} min). Use manual wind entry and verify ATIS/AWOS.`
+          )
+        }
+      }
+
       metar.value = {
         icaoId: raw.icaoId ?? icao.toUpperCase(),
         rawOb: raw.rawOb ?? '',
@@ -55,6 +107,7 @@ export function useMetar() {
         lat: raw.lat ?? 0,
         lon: raw.lon ?? 0,
         name: raw.name ?? '',
+        issuedAt,
       }
 
       console.log('Parsed METAR:', {
@@ -62,10 +115,11 @@ export function useMetar() {
         wspd: metar.value.wspd,
         wgst: metar.value.wgst,
         rawOb: metar.value.rawOb,
+        issuedAt: metar.value.issuedAt,
       })
 
       status.value = 'success'
-      lastFetchedAt.value = Date.now()
+      lastFetchedAt.value = nowMs
       console.log('✓ METAR fetch complete')
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)

--- a/src/constants/metar.ts
+++ b/src/constants/metar.ts
@@ -1,0 +1,3 @@
+// METAR should normally refresh at least hourly. If the latest report is older than
+// this limit, fail loudly so pilots can switch to manual/ATIS sources.
+export const METAR_MAX_AGE_MINUTES = 120

--- a/src/types/wind.ts
+++ b/src/types/wind.ts
@@ -7,6 +7,7 @@ export interface MetarData {
   lat: number
   lon: number
   name: string
+  issuedAt: number | null
 }
 
 export interface ParsedWind {


### PR DESCRIPTION
### Motivation

- Prevent silently using outdated METAR observations by rejecting excessively old METARs and forcing the pilot to use manual/ATIS sources when appropriate. 
- Make METAR freshness explicit to users by preferring the observation timestamp when available instead of only showing fetch time.

### Description

- Parse and persist an observation timestamp for METARs from `obsTime` (preferred) or by extracting the `DDHHMMZ` group from `rawOb`, stored as `issuedAt` on `MetarData` (`src/types/wind.ts`).
- Reject METAR responses older than `METAR_MAX_AGE_MINUTES` (added in `src/constants/metar.ts`) with a clear error instructing use of manual/ATIS sources (`src/composables/useMetar.ts`).
- Update freshness UI to prefer the METAR observation time and show `Observed …` when observation time exists, falling back to `Updated …` when only fetch time is available (`src/components/WindCheckerApp.vue`).
- Update and harden unit tests to cover issuedAt persistence, stale-METAR rejection, and the new freshness wording, and stabilize the assumptions panel toggle assertion (`src/__tests__/useMetar.spec.ts`, `src/__tests__/WindCheckerApp.test.ts`, `src/__tests__/AssumptionsDisplay.spec.ts`).

### Testing

- Ran unit tests with `npm run test:unit` and all tests passed (`49 passed`).
- Ran linters with `npm run lint` and the codebase is lint-clean.
- Added/updated unit tests that exercise the new stale-data guard and freshness messaging and they succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a25e78b6708322b09d76a68a5e7189)