### PR TITLE
Refactor: cleaner file structure, DRY CSS, and shared composable

### DIFF
--- a/src/components/ManualWindEntry.vue
+++ b/src/components/ManualWindEntry.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
 import type { ManualWindInput, ManualWindSource } from '@/composables/useManualWind'
 
-withDefaults(defineProps<{
-  theme?: 'light' | 'dark'
-}>(), {
-  theme: 'light',
-})
-
 const manualInput = defineModel<ManualWindInput>({ required: true })
 
 function updateField(
@@ -28,12 +22,8 @@ function setDeclinationDir(dir: 'E' | 'W') {
 <template>
   <div
     class="manual-entry"
-    :class="[
-      manualInput.source === 'atis_mag' ? 'mode-magnetic' : 'mode-true',
-      { 'theme-dark': theme === 'dark' },
-    ]"
+    :class="manualInput.source === 'atis_mag' ? 'mode-magnetic' : 'mode-true'"
   >
-
     <!-- Source selector -->
     <div class="mode-toggle">
       <button
@@ -145,52 +135,83 @@ function setDeclinationDir(dir: 'E' | 'W') {
         <span class="field-hint">blank = auto &nbsp;·&nbsp; toggle sets sign</span>
       </div>
     </div>
-
   </div>
 </template>
 
 <style scoped>
+/* ─── Mode color tokens (light) ──────────────────────────────── */
+
+.mode-true {
+  --mode-bg: #fefce8;
+  --mode-border: #fde047;
+  --mode-label: #78350f;
+  --mode-accent: #eab308;
+  --mode-accent-text: #1c1917;
+  --mode-input-bg: #fffbeb;
+  --mode-input-text: #1c1917;
+  --mode-input-border: #fbbf24;
+  --mode-input-focus: #d97706;
+  --mode-input-placeholder: #78716c;
+  --mode-reminder-bg: #fef9c3;
+  --mode-reminder-text: #713f12;
+}
+
+.mode-magnetic {
+  --mode-bg: #f0fdf4;
+  --mode-border: #86efac;
+  --mode-label: #15803d;
+  --mode-accent: #22c55e;
+  --mode-accent-text: #14532d;
+  --mode-input-bg: #f0fdf4;
+  --mode-input-text: #14532d;
+  --mode-input-border: #86efac;
+  --mode-input-focus: #22c55e;
+  --mode-input-placeholder: #4d7c0f;
+  --mode-reminder-bg: #dcfce7;
+  --mode-reminder-text: #14532d;
+}
+
+/* ─── Mode color tokens (dark) ───────────────────────────────── */
+
+:global([data-theme='dark']) .mode-true {
+  --mode-bg: #2b1d08;
+  --mode-border: #b45309;
+  --mode-label: #fcd34d;
+  --mode-input-bg: #2b1d08;
+  --mode-input-text: #fef3c7;
+  --mode-input-border: #d97706;
+  --mode-input-focus: #b45309;
+  --mode-input-placeholder: #fcd34d;
+  --mode-reminder-bg: #3b2a10;
+  --mode-reminder-text: #fde68a;
+}
+
+:global([data-theme='dark']) .mode-magnetic {
+  --mode-bg: #0f2619;
+  --mode-border: #166534;
+  --mode-label: #86efac;
+  --mode-input-bg: #0f2619;
+  --mode-input-text: #dcfce7;
+  --mode-input-border: #16a34a;
+  --mode-input-focus: #22c55e;
+  --mode-input-placeholder: #86efac;
+  --mode-reminder-bg: #123221;
+  --mode-reminder-text: #bbf7d0;
+}
+
+/* ─── Layout ─────────────────────────────────────────────────── */
+
 .manual-entry {
   border-radius: 8px;
   padding: 1rem 1.25rem;
   margin: 1rem 0;
-  border: 1px solid;
+  border: 1px solid var(--mode-border);
+  background: var(--mode-bg);
   transition: background 0.2s, border-color 0.2s;
 }
 
-.mode-true {
-  --manual-input-bg: #fffbeb;
-  --manual-input-text: #1c1917;
-  --manual-input-placeholder: #78716c;
-  background: #fefce8;
-  border-color: #fde047;
-}
+/* ─── Mode toggle ────────────────────────────────────────────── */
 
-.mode-magnetic {
-  --manual-input-bg: #f0fdf4;
-  --manual-input-text: #14532d;
-  --manual-input-placeholder: #4d7c0f;
-  background: #f0fdf4;
-  border-color: #86efac;
-}
-
-.theme-dark.mode-true {
-  --manual-input-bg: #2b1d08;
-  --manual-input-text: #fef3c7;
-  --manual-input-placeholder: #fcd34d;
-  background: #2b1d08;
-  border-color: #b45309;
-}
-
-.theme-dark.mode-magnetic {
-  --manual-input-bg: #0f2619;
-  --manual-input-text: #dcfce7;
-  --manual-input-placeholder: #86efac;
-  background: #0f2619;
-  border-color: #166534;
-}
-
-/* Mode toggle */
 .mode-toggle {
   display: inline-flex;
   border-radius: 6px;
@@ -219,46 +240,25 @@ function setDeclinationDir(dir: 'E' | 'W') {
   border-left: 1.5px solid var(--color-border);
 }
 
-.mode-true .mode-btn.active {
-  background: #eab308;
-  color: #1c1917;
+.mode-btn.active {
+  background: var(--mode-accent);
+  color: var(--mode-accent-text);
 }
 
-.mode-magnetic .mode-btn.active {
-  background: #22c55e;
-  color: #14532d;
-}
+/* ─── Source reminder ────────────────────────────────────────── */
 
-/* Source reminder */
 .source-reminder {
   font-size: 0.82rem;
   margin-bottom: 0.875rem;
   padding: 0.4rem 0.65rem;
   border-radius: 5px;
   line-height: 1.4;
+  background: var(--mode-reminder-bg);
+  color: var(--mode-reminder-text);
 }
 
-.mode-true .source-reminder {
-  background: #fef9c3;
-  color: #713f12;
-}
+/* ─── Fields ─────────────────────────────────────────────────── */
 
-.mode-magnetic .source-reminder {
-  background: #dcfce7;
-  color: #14532d;
-}
-
-.theme-dark.mode-true .source-reminder {
-  background: #3b2a10;
-  color: #fde68a;
-}
-
-.theme-dark.mode-magnetic .source-reminder {
-  background: #123221;
-  color: #bbf7d0;
-}
-
-/* Fields */
 .fields {
   display: flex;
   flex-wrap: wrap;
@@ -275,22 +275,7 @@ function setDeclinationDir(dir: 'E' | 'W') {
 .field label {
   font-size: 0.8rem;
   font-weight: 600;
-}
-
-.mode-true .field label {
-  color: #78350f;
-}
-
-.mode-magnetic .field label {
-  color: #15803d;
-}
-
-.theme-dark.mode-true .field label {
-  color: #fcd34d;
-}
-
-.theme-dark.mode-magnetic .field label {
-  color: #86efac;
+  color: var(--mode-label);
 }
 
 .field-hint {
@@ -299,6 +284,8 @@ function setDeclinationDir(dir: 'E' | 'W') {
   font-style: italic;
 }
 
+/* ─── Wind inputs ────────────────────────────────────────────── */
+
 .wind-input {
   padding: 0.4rem 0.6rem;
   border-radius: 5px;
@@ -306,39 +293,19 @@ function setDeclinationDir(dir: 'E' | 'W') {
   font-size: 1rem;
   width: 130px;
   outline: none;
-  border: 1.5px solid;
-  background: var(--manual-input-bg, var(--color-surface));
-  color: var(--manual-input-text, var(--color-text));
+  border: 1.5px solid var(--mode-input-border);
+  background: var(--mode-input-bg);
+  color: var(--mode-input-text);
   transition: border-color 0.15s;
 }
 
 .wind-input::placeholder {
-  color: var(--manual-input-placeholder, var(--color-text-muted));
+  color: var(--mode-input-placeholder);
   opacity: 1;
 }
 
-.mode-true .wind-input {
-  border-color: #fbbf24;
-}
-
-.mode-true .wind-input:focus {
-  border-color: #d97706;
-}
-
-.mode-magnetic .wind-input {
-  border-color: #86efac;
-}
-
-.mode-magnetic .wind-input:focus {
-  border-color: #22c55e;
-}
-
-.theme-dark.mode-true .wind-input {
-  border-color: #d97706;
-}
-
-.theme-dark.mode-magnetic .wind-input {
-  border-color: #16a34a;
+.wind-input:focus {
+  border-color: var(--mode-input-focus);
 }
 
 .wind-input.narrow {
@@ -348,6 +315,8 @@ function setDeclinationDir(dir: 'E' | 'W') {
 .wind-input.narrow-decl {
   width: 100px;
 }
+
+/* ─── Declination toggle ─────────────────────────────────────── */
 
 .declination-row {
   display: flex;
@@ -377,8 +346,8 @@ function setDeclinationDir(dir: 'E' | 'W') {
   border-left: 1.5px solid var(--color-border);
 }
 
-.mode-true .decl-btn.active {
-  background: #eab308;
-  color: #1c1917;
+.decl-btn.active {
+  background: var(--mode-accent);
+  color: var(--mode-accent-text);
 }
 </style>

--- a/src/components/WindCheckerApp.vue
+++ b/src/components/WindCheckerApp.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useMetar, parseMetarWind } from '@/composables/useMetar';
 import { useAirportInfo } from '@/composables/useAirportInfo';
 import { computeWindResult, buildHeadingTable } from '@/composables/useWindCalculations';
+import { useInterval } from '@/composables/useInterval';
 import { TAILWIND_LIMIT_KT } from '@/constants/windLimits';
 import type { MagneticCorrection, ParsedWind } from '@/types/wind';
 
@@ -14,6 +15,8 @@ import AssumptionsDisplay from './AssumptionsDisplay.vue';
 import SafetyReadout from './SafetyReadout.vue';
 import CompassRose from './CompassRose.vue';
 import HeadingTable from './HeadingTable.vue';
+import StatusMessage from './ui/StatusMessage.vue';
+import ErrorPanel from './ui/ErrorPanel.vue';
 
 withDefaults(defineProps<{
   theme?: 'light' | 'dark'
@@ -47,8 +50,18 @@ const activeIcao = ref('');
 const isOnline = ref(typeof navigator === 'undefined' ? true : navigator.onLine);
 const freshnessNowMs = ref(Date.now());
 
-let freshnessIntervalId: number | null = null;
-let autoRefreshIntervalId: number | null = null;
+// --- Intervals ---
+useInterval(() => {
+  freshnessNowMs.value = Date.now();
+}, 60_000);
+
+useInterval(() => {
+  if (!isOnline.value) return;
+  if (manualMode.value) return;
+  if (metarStatus.value !== 'success') return;
+  if (activeIcao.value.length < 3) return;
+  void fetchMetar(activeIcao.value);
+}, 300_000);
 
 // --- Fetch orchestration ---
 async function onFetch(icao: string) {
@@ -71,15 +84,12 @@ function continueWithZeroDecl() {
 }
 
 // --- Error state helpers ---
-// Both failed
 const bothFailed = computed(() =>
   metarStatus.value === 'error' && airportStatus.value === 'error'
 );
-// Only METAR failed (airport may have succeeded or errored)
 const onlyMetarFailed = computed(() =>
   metarStatus.value === 'error' && airportStatus.value !== 'error'
 );
-// Only airport failed but METAR succeeded — offer "continue with 0° decl"
 const onlyAirportFailed = computed(() =>
   metarStatus.value === 'success' && airportStatus.value === 'error' && !useZeroDecl.value
 );
@@ -169,18 +179,6 @@ function handleOnline() {
 }
 
 onMounted(() => {
-  freshnessIntervalId = window.setInterval(() => {
-    freshnessNowMs.value = Date.now();
-  }, 60_000);
-
-  autoRefreshIntervalId = window.setInterval(() => {
-    if (!isOnline.value) return;
-    if (manualMode.value) return;
-    if (metarStatus.value !== 'success') return;
-    if (activeIcao.value.length < 3) return;
-    void fetchMetar(activeIcao.value);
-  }, 300_000);
-
   window.addEventListener('offline', handleOffline);
   window.addEventListener('online', handleOnline);
 
@@ -190,12 +188,6 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  if (freshnessIntervalId !== null) {
-    window.clearInterval(freshnessIntervalId);
-  }
-  if (autoRefreshIntervalId !== null) {
-    window.clearInterval(autoRefreshIntervalId);
-  }
   window.removeEventListener('offline', handleOffline);
   window.removeEventListener('online', handleOnline);
 });
@@ -259,9 +251,9 @@ watch(manualMode, (enabled) => {
 
     <p v-if="metarFreshnessText" class="metar-freshness">{{ metarFreshnessText }}</p>
 
-    <div v-if="!isOnline" class="status-msg warning">
+    <StatusMessage v-if="!isOnline" variant="warning">
       Offline: METAR retrieval is unavailable. Manual wind entry is required.
-    </div>
+    </StatusMessage>
 
     <!-- Manual mode toggle -->
     <div class="manual-toggle">
@@ -272,16 +264,18 @@ watch(manualMode, (enabled) => {
     </div>
 
     <!-- Manual entry panel -->
-    <ManualWindEntry v-if="manualMode" v-model="manualInputs" :theme="theme" />
+    <ManualWindEntry v-if="manualMode" v-model="manualInputs" />
 
     <!-- Loading indicator -->
-    <div v-if="isLoading" class="status-msg loading">
+    <StatusMessage v-if="isLoading" variant="loading">
       Fetching data…
-    </div>
+    </StatusMessage>
 
     <!-- Both fetches failed -->
-    <div v-else-if="bothFailed && !manualMode" class="error-panel">
-      <p class="error-title">Could not retrieve data</p>
+    <ErrorPanel
+      v-else-if="bothFailed && !manualMode"
+      title="Could not retrieve data"
+    >
       <p class="error-detail"><strong>METAR:</strong> {{ metarError }}</p>
       <p class="error-detail"><strong>Airport info:</strong> {{ airportError }}</p>
       <div class="error-actions">
@@ -289,24 +283,28 @@ watch(manualMode, (enabled) => {
           Enter winds manually
         </button>
       </div>
-    </div>
+    </ErrorPanel>
 
     <!-- Only METAR failed -->
-    <div v-else-if="onlyMetarFailed && !manualMode" class="error-panel">
-      <p class="error-title">METAR fetch failed</p>
+    <ErrorPanel
+      v-else-if="onlyMetarFailed && !manualMode"
+      title="METAR fetch failed"
+    >
       <p class="error-detail">{{ metarError }}</p>
-      <p class="error-hint">You can enter winds manually below. Airport magnetic declination was retrieved successfully.
-      </p>
+      <p class="error-hint">You can enter winds manually below. Airport magnetic declination was retrieved successfully.</p>
       <div class="error-actions">
         <button class="action-btn primary" @click="enableManualMode">
           Enter winds manually
         </button>
       </div>
-    </div>
+    </ErrorPanel>
 
     <!-- METAR succeeded but airport info failed — user must choose -->
-    <div v-else-if="onlyAirportFailed" class="error-panel warn">
-      <p class="error-title">Airport declination unavailable</p>
+    <ErrorPanel
+      v-else-if="onlyAirportFailed"
+      variant="warn"
+      title="Airport declination unavailable"
+    >
       <p class="error-detail">{{ airportError }}</p>
       <p class="error-hint">
         METAR winds are reported in <strong>TRUE</strong> degrees. Without a declination value they
@@ -322,26 +320,26 @@ watch(manualMode, (enabled) => {
           <span class="action-note">(enter magnetic direction directly)</span>
         </button>
       </div>
-    </div>
+    </ErrorPanel>
 
     <!-- Results -->
     <template v-if="windResult">
       <!-- Zero-decl warning banner -->
-      <div v-if="useZeroDecl" class="status-msg warning">
+      <StatusMessage v-if="useZeroDecl" variant="warning">
         <strong>Warning:</strong> No declination applied — METAR winds are TRUE degrees.
         Magnetic variation at this airport is unknown. Verify against ATIS/AWOS.
-      </div>
+      </StatusMessage>
 
       <AssumptionsDisplay :result="windResult" :raw-metar="rawMetar" />
       <SafetyReadout :result="windResult" />
       <CompassRose :result="windResult" />
       <HeadingTable v-if="headingRows.length > 0" :rows="headingRows" />
-      <p v-else-if="windResult.parsedWind.isCalm" class="status-msg calm">
+      <StatusMessage v-else-if="windResult.parsedWind.isCalm" variant="calm">
         No table shown for calm winds.
-      </p>
-      <p v-else-if="windResult.parsedWind.isVariable" class="status-msg warning">
+      </StatusMessage>
+      <StatusMessage v-else-if="windResult.parsedWind.isVariable" variant="warning">
         Table not available for variable winds — any heading may be unsafe.
-      </p>
+      </StatusMessage>
     </template>
 
     <!-- Idle state -->
@@ -445,118 +443,6 @@ watch(manualMode, (enabled) => {
   width: 1rem;
   height: 1rem;
   cursor: pointer;
-}
-
-/* Error panel */
-.error-panel {
-  background: var(--color-unsafe-bg);
-  border: 1px solid var(--color-unsafe-border);
-  border-left: 4px solid var(--color-unsafe);
-  border-radius: 8px;
-  padding: 1rem 1.25rem;
-  margin: 0.75rem 0;
-}
-
-.error-panel.warn {
-  background: var(--color-warning-bg);
-  border-color: var(--color-warning-border);
-  border-left-color: var(--color-warning);
-}
-
-.error-title {
-  font-weight: 700;
-  font-size: 1rem;
-  color: var(--color-unsafe-text);
-  margin: 0 0 0.4rem;
-}
-
-.error-panel.warn .error-title {
-  color: var(--color-warning-text);
-}
-
-.error-detail {
-  font-size: 0.875rem;
-  color: var(--color-unsafe-text);
-  margin: 0.2rem 0;
-  font-family: var(--font-mono);
-}
-
-.error-panel.warn .error-detail {
-  color: var(--color-warning-text);
-}
-
-.error-hint {
-  font-size: 0.875rem;
-  color: var(--color-text-subtle);
-  margin: 0.5rem 0 0.75rem;
-}
-
-.error-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 0.75rem;
-}
-
-.action-btn {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.action-btn.primary {
-  background: var(--color-primary);
-  color: var(--color-primary-text);
-}
-
-.action-btn.primary:hover {
-  background: var(--color-primary-hover);
-}
-
-.action-btn.secondary {
-  background: var(--color-secondary-bg);
-  color: var(--color-secondary-text);
-}
-
-.action-btn.secondary:hover {
-  background: var(--color-secondary-hover);
-}
-
-.action-note {
-  font-size: 0.75rem;
-  font-weight: 400;
-  opacity: 0.8;
-  margin-top: 0.15rem;
-}
-
-/* Status messages */
-.status-msg {
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin: 0.75rem 0;
-  font-size: 0.9rem;
-}
-
-.status-msg.loading {
-  background: var(--color-info-bg);
-  color: var(--color-info-text);
-}
-
-.status-msg.calm {
-  background: var(--color-safe-bg);
-  color: var(--color-safe-text);
-}
-
-.status-msg.warning {
-  background: var(--color-warning-bg);
-  color: var(--color-warning-text);
 }
 
 .idle-prompt {

--- a/src/components/ui/ErrorPanel.vue
+++ b/src/components/ui/ErrorPanel.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+defineProps<{
+  variant?: 'error' | 'warn'
+  title: string
+}>()
+</script>
+
+<template>
+  <div class="error-panel" :class="variant ?? 'error'">
+    <p class="error-title">{{ title }}</p>
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.error-panel {
+  background: var(--color-unsafe-bg);
+  border: 1px solid var(--color-unsafe-border);
+  border-left: 4px solid var(--color-unsafe);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin: 0.75rem 0;
+}
+
+.error-panel.warn {
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning-border);
+  border-left-color: var(--color-warning);
+}
+
+.error-title {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--color-unsafe-text);
+  margin: 0 0 0.4rem;
+}
+
+.error-panel.warn .error-title {
+  color: var(--color-warning-text);
+}
+
+/* ── Slot content styles ─────────────────────────────────────── */
+
+:slotted(.error-detail) {
+  font-size: 0.875rem;
+  color: var(--color-unsafe-text);
+  margin: 0.2rem 0;
+  font-family: var(--font-mono);
+}
+
+.error-panel.warn :slotted(.error-detail) {
+  color: var(--color-warning-text);
+}
+
+:slotted(.error-hint) {
+  font-size: 0.875rem;
+  color: var(--color-text-subtle);
+  margin: 0.5rem 0 0.75rem;
+}
+
+:slotted(.error-actions) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+:slotted(.action-btn) {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+:slotted(.action-btn.primary) {
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+:slotted(.action-btn.primary:hover) {
+  background: var(--color-primary-hover);
+}
+
+:slotted(.action-btn.secondary) {
+  background: var(--color-secondary-bg);
+  color: var(--color-secondary-text);
+}
+
+:slotted(.action-btn.secondary:hover) {
+  background: var(--color-secondary-hover);
+}
+
+:slotted(.action-note) {
+  font-size: 0.75rem;
+  font-weight: 400;
+  opacity: 0.8;
+  margin-top: 0.15rem;
+}
+</style>

--- a/src/components/ui/StatusMessage.vue
+++ b/src/components/ui/StatusMessage.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+defineProps<{
+  variant: 'loading' | 'calm' | 'warning'
+}>()
+</script>
+
+<template>
+  <div class="status-msg" :class="variant">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.status-msg {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin: 0.75rem 0;
+  font-size: 0.9rem;
+}
+
+.loading {
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
+}
+
+.calm {
+  background: var(--color-safe-bg);
+  color: var(--color-safe-text);
+}
+
+.warning {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+}
+</style>

--- a/src/composables/useInterval.ts
+++ b/src/composables/useInterval.ts
@@ -1,0 +1,17 @@
+import { onMounted, onUnmounted } from 'vue'
+
+/**
+ * Manages a repeating interval that starts automatically on mount
+ * and is cleaned up on unmount. Must be called within component setup.
+ */
+export function useInterval(fn: () => void, ms: number): void {
+  let id: number | null = null
+
+  onMounted(() => {
+    id = window.setInterval(fn, ms)
+  })
+
+  onUnmounted(() => {
+    if (id !== null) window.clearInterval(id)
+  })
+}


### PR DESCRIPTION
File structure:
- Add src/components/ui/ with StatusMessage.vue and ErrorPanel.vue,
  extracting repeated status-message and error-panel patterns from
  WindCheckerApp into reusable slot-based components

CSS:
- Remove theme prop from ManualWindEntry; replace all hardcoded hex
  colors with --mode-* CSS custom properties defined per mode class,
  with dark overrides via :global([data-theme='dark']). This eliminates
  ~20 duplicated light/dark rule pairs and removes prop threading.

Code DRY:
- Add useInterval composable that auto-starts on mount and cleans up
  on unmount, replacing the raw setInterval/clearInterval boilerplate
  and null-check guards in WindCheckerApp 