### PR TITLE
build: migrate app shell to Nuxt SSR with Netlify deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ This is not an official Airbus or airline application. Always verify all wind/pe
 
 ## Tech stack
 
-- Vue 3 + TypeScript
-- Vite
+- Nuxt 3 (Vue 3 + TypeScript, SSR enabled)
 - Vitest + Vue Test Utils
 - Playwright
 
@@ -29,13 +28,14 @@ npm install
 npm run dev
 ```
 
-Open the local URL shown by Vite (normally `http://localhost:5173`).
+Open the local URL shown by Nuxt (normally `http://localhost:3000`).
 
 ## Scripts
 
-- `npm run dev`: Start the Vite dev server.
-- `npm run build`: Type-check and create a production build in `dist/`.
-- `npm run preview`: Serve the production build locally.
+- `npm run dev`: Start the Nuxt development server.
+- `npm run build`: Build the SSR app with Nitro output.
+- `npm run preview`: Serve the production Nuxt build locally.
+- `npm run type-check`: Run Nuxt type-checking.
 - `npm run test:unit`: Run Vitest unit tests.
 - `npm run test:e2e`: Run Playwright end-to-end tests.
 - `npm run lint`: Run lint auto-fixes (`oxlint` + `eslint`).
@@ -67,7 +67,7 @@ npm run test:e2e -- --debug
 
 ## Deployment
 
-GitHub Pages deployment is configured via `.github/workflows/deploy.yml` and publishes `dist/` to `gh-pages`.
+This project is configured for Nuxt SSR deployment to Netlify using Nitro's Netlify preset (`NITRO_PRESET=netlify`). The generated server/public output is managed by Nuxt/Nitro during `npm run build`.
 
 ## Branch strategy
 

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,4 @@
+<template>
+  <NuxtRouteAnnouncer />
+  <NuxtPage />
+</template>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  command = "npm run build"
+
+[build.environment]
+  NITRO_PRESET = "netlify"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,15 @@
+export default defineNuxtConfig({
+  ssr: true,
+  srcDir: '.',
+  compatibilityDate: '2025-01-01',
+  devtools: { enabled: true },
+  alias: {
+    '@': '/src',
+  },
+  runtimeConfig: {
+    avwxToken: '',
+    public: {
+      appBaseUrl: '/',
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "dev:host": "vite --host",
-    "build": "run-p type-check \"build-only {@}\" --",
-    "preview": "vite preview",
+    "dev": "nuxt dev",
+    "dev:host": "nuxt dev --host",
+    "build": "nuxt build",
+    "preview": "nuxt preview",
     "test:unit": "vitest",
     "test:e2e": "playwright test",
-    "build-only": "vite build",
-    "type-check": "vue-tsc --build",
+    "type-check": "nuxt typecheck",
     "lint": "run-s lint:*",
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache"
@@ -19,14 +18,13 @@
   "dependencies": {
     "geomagnetism": "^0.2.0",
     "vue": "^3.5.29",
-    "vue-router": "^5.0.3"
+    "nuxt": "^3.17.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tsconfig/node24": "^24.0.4",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.10.13",
-    "@vitejs/plugin-vue": "^6.0.4",
     "@vitest/eslint-plugin": "^1.6.9",
     "@vue/eslint-config-typescript": "^14.7.0",
     "@vue/test-utils": "^2.4.6",
@@ -40,10 +38,10 @@
     "npm-run-all2": "^8.0.4",
     "oxlint": "~1.50.0",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1",
-    "vite-plugin-vue-devtools": "^8.0.6",
     "vitest": "^4.0.18",
-    "vue-tsc": "^3.2.5"
+    "vue-tsc": "^3.2.5",
+    "@vitejs/plugin-vue": "^6.0.4",
+    "vite": "^7.3.1"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import App from '@/App.vue'
+
+defineOptions({
+  name: 'HomePage',
+})
+</script>
+
+<template>
+  <App />
+</template>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:5173',
+    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -104,7 +104,7 @@ export default defineConfig({
      * Playwright will re-use the local server if there is already a dev-server running.
      */
     command: process.env.CI ? 'npm run preview' : 'npm run dev',
-    port: process.env.CI ? 4173 : 5173,
+    port: 3000,
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/plugins/pwa.client.ts
+++ b/plugins/pwa.client.ts
@@ -1,0 +1,19 @@
+export default defineNuxtPlugin(() => {
+  if (!('serviceWorker' in navigator)) {
+    return
+  }
+
+  const config = useRuntimeConfig()
+
+  window.addEventListener('load', async () => {
+    try {
+      const baseUrl = config.public.appBaseUrl ?? '/'
+      await navigator.serviceWorker.register(`${baseUrl}sw.js`, {
+        scope: baseUrl,
+      })
+      console.log('[PWA] Service worker registered')
+    } catch (err) {
+      console.error('[PWA] Service worker registration failed:', err)
+    }
+  })
+})

--- a/server/api/avwx-rest/metar/[icao].ts
+++ b/server/api/avwx-rest/metar/[icao].ts
@@ -1,0 +1,28 @@
+export default defineEventHandler(async (event) => {
+  const icao = getRouterParam(event, 'icao')
+  const config = useRuntimeConfig(event)
+
+  if (!icao) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing ICAO code' })
+  }
+
+  if (!config.avwxToken) {
+    throw createError({ statusCode: 500, statusMessage: 'AVWX API token is not configured' })
+  }
+
+  const upstreamUrl = `https://avwx.rest/api/metar/${encodeURIComponent(icao.toUpperCase())}?options=info`
+
+  try {
+    return await $fetch(upstreamUrl, {
+      headers: {
+        Authorization: `Token ${config.avwxToken}`,
+      },
+    })
+  } catch (error) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'AVWX upstream request failed',
+      data: error,
+    })
+  }
+})

--- a/server/api/avwx/[...path].ts
+++ b/server/api/avwx/[...path].ts
@@ -1,0 +1,19 @@
+export default defineEventHandler(async (event) => {
+  const path = getRouterParam(event, 'path')
+  if (!path) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing AviationWeather API path' })
+  }
+
+  const query = getRequestURL(event).search
+  const upstreamUrl = `https://aviationweather.gov/api/data/${path}${query}`
+
+  try {
+    return await $fetch(upstreamUrl)
+  } catch (error) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'AviationWeather upstream request failed',
+      data: error,
+    })
+  }
+})

--- a/src/__tests__/WindCheckerApp.test.ts
+++ b/src/__tests__/WindCheckerApp.test.ts
@@ -156,8 +156,10 @@ describe('WindCheckerApp', () => {
     await fetchButton.trigger('click')
     await flushAsyncUpdates()
 
-    expect(wrapper.text()).toContain('Issued at 10:00Z')
-    expect(wrapper.text()).toContain('Time now is 10:00Z')
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('Issued at 10:00Z')
+      expect(wrapper.text()).toContain('Time now is 10:00Z')
+    })
 
     await vi.advanceTimersByTimeAsync(31 * 60_000)
     await flushAsyncUpdates()

--- a/src/composables/aviationWeatherApi.ts
+++ b/src/composables/aviationWeatherApi.ts
@@ -1,13 +1,7 @@
-function buildAviationWeatherEndpoint(path: string): string {
-  return `https://aviationweather.gov/api/data${path}`
-}
 
-function withCorsProxy(url: string): string {
-  return `https://corsproxy.io/?${encodeURIComponent(url)}`
-}
-
-function withIsomorphicCorsProxy(url: string): string {
-  return `https://cors.isomorphic-git.org/${url}`
+function resolveRequestUrl(url: string): string {
+  if (!url.startsWith('/') || typeof window === 'undefined') return url
+  return new URL(url, window.location.origin).toString()
 }
 
 function classifyProxy(url: string): string {
@@ -33,7 +27,7 @@ export async function fetchJsonWithFallback<T>(urls: string[]): Promise<T> {
   for (const url of urls) {
     try {
       console.log('[AviationWeather] Fetch attempt:', url)
-      const response = await fetch(url)
+      const response = await fetch(resolveRequestUrl(url))
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }
@@ -52,17 +46,5 @@ export async function fetchJsonWithFallback<T>(urls: string[]): Promise<T> {
 }
 
 export async function fetchAviationWeatherJson<T>(path: string): Promise<T> {
-  const directUrl = buildAviationWeatherEndpoint(path)
-
-  if (import.meta.env.DEV) {
-    return fetchJsonWithFallback<T>([`/api/avwx${path}`])
-  }
-
-  // gh-pages deployments hit CORS restrictions when calling aviationweather.gov directly.
-  // Use CORS proxies in production to avoid direct-browser CORS failures.
-  return fetchJsonWithFallback<T>([
-    withIsomorphicCorsProxy(directUrl),
-    withCorsProxy(directUrl),
-    directUrl,
-  ])
+  return fetchJsonWithFallback<T>([`/api/avwx${path}`])
 }

--- a/src/composables/avwxApi.ts
+++ b/src/composables/avwxApi.ts
@@ -1,4 +1,8 @@
-const AVWX_TOKEN: string | undefined = import.meta.env.VITE_AVWX_TOKEN
+
+function resolveRequestUrl(url: string): string {
+  if (!url.startsWith('/') || typeof window === 'undefined') return url
+  return new URL(url, window.location.origin).toString()
+}
 
 interface AvwxWindField {
   value: number | null
@@ -23,22 +27,14 @@ export interface AvwxMetarResponse {
 }
 
 export function isAvwxAvailable(): boolean {
-  return typeof AVWX_TOKEN === 'string' && AVWX_TOKEN.length > 0
+  return false
 }
 
 export async function fetchAvwxMetar(icao: string): Promise<AvwxMetarResponse> {
-  if (!AVWX_TOKEN) {
-    throw new Error('AVWX API token not configured')
-  }
-
-  // avwx.rest is a proper CORS-enabled API — no proxy needed.
-  // ?options=info includes station lat/lon/name in the response.
-  const url = `https://avwx.rest/api/metar/${encodeURIComponent(icao.toUpperCase())}?options=info`
+  const url = `/api/avwx-rest/metar/${encodeURIComponent(icao.toUpperCase())}`
   console.log('[AVWX] Fetch attempt:', url)
 
-  const response = await fetch(url, {
-    headers: { Authorization: `Token ${AVWX_TOKEN}` },
-  })
+  const response = await fetch(resolveRequestUrl(url))
 
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}: ${response.statusText}`)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,27 +1,12 @@
-import { fileURLToPath, URL } from "node:url";
-
-import { defineConfig } from "vite";
-import vue from "@vitejs/plugin-vue";
-import vueDevTools from "vite-plugin-vue-devtools";
-
-// https://vite.dev/config/
-const isGitHubPagesBuild = process.env.GITHUB_ACTIONS === "true";
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
-  plugins: [vue(), vueDevTools()],
+  plugins: [vue()],
   resolve: {
     alias: {
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
-  server: {
-    proxy: {
-      "/api/avwx": {
-        target: "https://aviationweather.gov",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api\/avwx/, "/api/data"),
-      },
-    },
-  },
-  base: isGitHubPagesBuild ? "/A220Tools/" : "/",
-});
+})


### PR DESCRIPTION
### Motivation
- Move the app from a Vite SPA to a Nuxt 3 SSR entry so the app can use server-side endpoints and deploy to Netlify using Nitro's Netlify preset.
- Proxy aviation data fetches through backend endpoints to avoid CORS issues in SSR/Netlify deployments and centralize API token use.
- Keep existing Vue 3 app logic and tests intact while enabling SSR and Netlify-friendly build/runtime behavior.

### Description
- Added Nuxt scaffold and runtime config: `nuxt.config.ts`, root `app.vue`, and `pages/index.vue` to render the current `App.vue` under Nuxt conventions and enable SSR. 
- Added Nitro/Netlify config and PWA plugin: `netlify.toml` (sets `NITRO_PRESET=netlify`) and `plugins/pwa.client.ts` to register the service worker during client load. 
- Introduced server API routes: `server/api/avwx/[...path].ts` (proxy to `aviationweather.gov`) and `server/api/avwx-rest/metar/[icao].ts` (proxy to `avwx.rest` with token from runtime config). 
- Updated client fetch logic to use backend endpoints and safe URL resolution: `src/composables/aviationWeatherApi.ts` now routes via `/api/avwx` and uses `resolveRequestUrl(...)`, and `src/composables/avwxApi.ts` uses `/api/avwx-rest/...` and `resolveRequestUrl(...)`; AVWX availability detection is set to `false` so the app falls back to the AviationWeather proxy path by default in this migration. 
- Switched npm scripts and dependencies toward Nuxt: updated `package.json` scripts to `nuxt dev|build|preview`, added `nuxt` as a runtime dependency, and kept test tooling (`vitest`/Playwright) for continued unit/e2e workflows. 
- Adjusted tooling/config for the new dev server: simplified `vite.config.ts` to remain compatible with Vitest, updated `playwright.config.ts` base URL and port to Nuxt defaults, and stabilized an async unit test by switching to `vi.waitFor(...)` in `src/__tests__/WindCheckerApp.test.ts`.

### Testing
- Ran linting with `npm run lint` and auto-fixes; lint completed successfully. (✅)
- Ran the targeted unit test file with `npx vitest run src/__tests__/WindCheckerApp.test.ts`; the suite passed after the async-wait stabilization change. (✅)
- Ran full unit test run `npm run test:unit -- --run`; an existing intermittent test (`src/__tests__/AssumptionsDisplay.spec.ts` — "starts collapsed and toggles open") still fails intermittently and remains unchanged in intent; overall most tests pass. (⚠️ intermittent failure)
- Attempted `npm install` / `npm run build` to validate Nuxt build, but `npm install` failed in this environment with `403 Forbidden - GET https://registry.npmjs.org/nuxt`, so `nuxt` could not be installed and `nuxt build` could not be executed here. Please run `npm install` and `npm run build` in an environment with registry access to fully validate the build. (⚠️ blocked)

If you want, I can: run a follow-up that wires `AVWX` token usage into runtime config for production, or revert the `isAvwxAvailable` behavior and add docs explaining local development vs deployed behavior, or help run the full `npm install`/`npm run build` in CI with registry access and a configured `AVWX` token.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39ddcef3883228ab5d102ef772c87)