### PR TITLE
deploy: add Railway config + Nixpacks and start script for Nuxt SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,24 @@ npm run test:e2e -- --debug
 - `src/__tests__/`: Unit tests.
 - `e2e/`: Playwright specs.
 
-## Deployment
+## Deployment (Railway)
 
-This project is configured for Nuxt SSR deployment to Netlify using Nitro's Netlify preset (`NITRO_PRESET=netlify`). The generated server/public output is managed by Nuxt/Nitro during `npm run build`.
+This project is configured for Nuxt SSR deployment to Railway using configuration-as-code. Railway uses `railway.toml` for deploy orchestration and `nixpacks.toml` to pin Node/build/start commands.
+
+### Railway runtime details
+
+- Build command: `npm run build`
+- Runtime command: `node .output/server/index.mjs`
+- Health check path: `/`
+
+### Deploy steps
+
+1. Create a new Railway project and link this repository.
+2. Ensure Railway is set to use the repo-root `railway.toml` + `nixpacks.toml` (default when present).
+3. Deploy from `master` (or your selected release branch).
+4. For custom domains, set `NUXT_PUBLIC_APP_BASE_URL` as needed.
+
+Nuxt/Nitro generates the production server bundle in `.output/` during `npm run build`, which Railway starts via the configured start command.
 
 ## Branch strategy
 

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+[phases.setup]
+nixPkgs = ["nodejs_22"]
+
+[phases.install]
+cmds = ["npm ci"]
+
+[phases.build]
+cmds = ["npm run build"]
+
+[start]
+cmd = "node .output/server/index.mjs"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,7 +24,7 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     public: {
-      appBaseUrl: '/',
+      appBaseUrl: process.env.NUXT_PUBLIC_APP_BASE_URL || '/',
     },
   },
 })

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "type-check": "nuxt typecheck",
     "lint": "run-s lint:*",
     "lint:oxlint": "oxlint . --fix",
-    "lint:eslint": "eslint . --fix --cache"
+    "lint:eslint": "eslint . --fix --cache",
+    "start": "node .output/server/index.mjs"
   },
   "dependencies": {
     "geomagnetism": "^0.2.0",

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "NIXPACKS"
+
+[deploy]
+numReplicas = 1
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10
+startCommand = "node .output/server/index.mjs"
+healthcheckPath = "/"
+healthcheckTimeout = 100


### PR DESCRIPTION
### Motivation

- Support deploying the Nuxt SSR app to Railway using configuration-as-code instead of the current Netlify guidance.  
- Make build/install/start phases deterministic in Railway by pinning Nixpacks phases and runtime start command.  
- Expose runtime base URL via environment (`NUXT_PUBLIC_APP_BASE_URL`) so Railway/custom domains can override `appBaseUrl`.

### Description

- Add `railway.toml` to define Railway deploy settings (builder `NIXPACKS`, `startCommand`, replicas, restart policy, and healthcheck).  
- Add `nixpacks.toml` to pin Node runtime and to run `npm ci` and `npm run build` during Railway builds and to start the Nuxt SSR output with `node .output/server/index.mjs`.  
- Add a `start` script to `package.json` (`node .output/server/index.mjs`) so local/prod start behavior aligns with Railway.  
- Update `nuxt.config.ts` to set `appBaseUrl` from `process.env.NUXT_PUBLIC_APP_BASE_URL || '/'` for runtime configurability.  
- Update `README.md` deployment section to describe Railway runtime details and deploy steps.

### Testing

- Ran lint via `npm run lint` and it completed successfully.  
- Ran unit tests via `npm run test:unit`; most tests passed but one flaky test failed: `src/__tests__/AssumptionsDisplay.spec.ts` (toggle visibility assertion).  
- Attempted `npm run build` but the environment couldn't complete `npm install` (registry access blocked) and the `nuxt` binary was unavailable so the build could not be validated here.  
- No e2e/preview runs were performed in this environment due to the build/runtime blockers described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d649acc48322b380f6abacbb8a22)