### PR TITLE
Replace GitHub Pages app with redirect to Railway deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,23 +1,18 @@
 <!DOCTYPE html>
-<html lang="">
-
+<html lang="en">
 <head>
   <meta charset="UTF-8">
-  <link rel="apple-touch-icon" sizes="180x180" href="/A220Tools/icons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/A220Tools/icons/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/A220Tools/icons/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <link rel="manifest" href="/A220Tools/manifest.webmanifest">
+  <meta http-equiv="refresh" content="0; url=https://a220tools-production.up.railway.app">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="theme-color" content="#1e40af">
-  <meta name="apple-mobile-web-app-capable" content="yes">
-  <title>A220 Start Calc</title>
-  <script type="module" crossorigin src="/A220Tools/assets/index-Rxs9NWBV.js"></script>
-  <link rel="stylesheet" crossorigin href="/A220Tools/assets/index-Btg5rMIb.css">
+  <title>Redirecting…</title>
+  <script>
+    window.location.replace('https://a220tools-production.up.railway.app');
+  </script>
 </head>
-
 <body>
-  <div id="app"></div>
+  <p>
+    Redirecting to
+    <a href="https://a220tools-production.up.railway.app">a220tools-production.up.railway.app</a>…
+  </p>
 </body>
-
 </html>


### PR DESCRIPTION
### Motivation
- The GitHub Pages site should stop serving the full app and instead immediately redirect visitors to the Railway deployment at `https://a220tools-production.up.railway.app`.

### Description
- Replaced the existing `index.html` app shell with a lightweight redirect page that points to `https://a220tools-production.up.railway.app`.
- Added an immediate meta-refresh (`<meta http-equiv="refresh" ...>`) and a JavaScript fallback using `window.location.replace` for fast client-side redirects.
- Added a clickable fallback link in the body for no-JS/manual access and removed references to app assets and icons from the page.
- Ensured the document language attribute is set (`<html lang="en">`).

### Testing
- Verified the redirect strings are present with `rg -n "railway.app|refresh|location.replace" index.html` and the command returned the expected matches.
- Served the modified site locally with `python3 -m http.server 4173` and validated the page responded as expected.
- Captured a rendering of the page using a Playwright script which produced `artifacts/redirect-page.png`, confirming the meta/JS/link redirect targets are visible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4735baca48322a2206964fa93ab84)