### PR TITLE
Update redirect page target to www.220stuff.app

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://a220tools-production.up.railway.app">
+  <meta http-equiv="refresh" content="0; url=https://www.220stuff.app">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Redirecting…</title>
   <script>
-    window.location.replace('https://a220tools-production.up.railway.app');
+    window.location.replace('https://www.220stuff.app');
   </script>
 </head>
 <body>
   <p>
     Redirecting to
-    <a href="https://a220tools-production.up.railway.app">a220tools-production.up.railway.app</a>…
+    <a href="https://www.220stuff.app">www.220stuff.app</a>…
   </p>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Change the root redirect to the new canonical domain `www.220stuff.app` instead of the previous `a220tools-production.up.railway.app`.

### Description
- Updated `index.html` to replace the meta refresh URL, the `window.location.replace(...)` target, and the fallback anchor href/text to `https://www.220stuff.app`.

### Testing
- Started a local server with `python3 -m http.server`, loaded `index.html` with Playwright to capture a screenshot, and inspected the staged diff with `git diff --cached` to confirm the edits; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48b26909c83228e870d3e46b697aa)